### PR TITLE
Add basic VNC integration

### DIFF
--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -1,0 +1,22 @@
+name: Validate
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+
+jobs:
+  validate:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - name: HACS validation
+        uses: hacs/action@main
+        with:
+          category: integration
+      - name: Hassfest
+        uses: home-assistant/actions/hassfest@main
+      - name: Tests
+        run: |
+          python -m pytest

--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,0 +1,1 @@
+custom_components/vnc/ @404GamerNotFound

--- a/README.md
+++ b/README.md
@@ -1,2 +1,6 @@
 # ha-vnc
 
+Custom integration for Home Assistant that exposes a basic VNC viewer using
+noVNC. After installing through HACS, add the integration via the UI and
+configure the host and port of the VNC server. A new sidebar panel will appear
+that opens the remote desktop within Home Assistant.

--- a/README.md
+++ b/README.md
@@ -4,3 +4,10 @@ Custom integration for Home Assistant that exposes a basic VNC viewer using
 noVNC. After installing through HACS, add the integration via the UI and
 configure the host and port of the VNC server. A new sidebar panel will appear
 that opens the remote desktop within Home Assistant.
+
+## HACS
+
+This repository works with [HACS](https://hacs.xyz/). Add it as a custom repository and install the VNC integration.
+
+- Code owner: [404GamerNotFound](https://github.com/404GamerNotFound)
+- Documentation: https://Brüser.com

--- a/custom_components/vnc/__init__.py
+++ b/custom_components/vnc/__init__.py
@@ -1,0 +1,85 @@
+from __future__ import annotations
+
+import asyncio
+from aiohttp import web, WSMsgType
+from homeassistant.components.http import HomeAssistantView
+from homeassistant.config_entries import ConfigEntry
+from homeassistant.const import CONF_HOST, CONF_PORT
+from homeassistant.core import HomeAssistant
+
+from .const import DOMAIN
+
+
+class VncProxyView(HomeAssistantView):
+    """Proxy VNC traffic over a Home Assistant websocket."""
+
+    url = "/api/vnc/{entry_id}"
+    name = "api:vnc"
+    requires_auth = True
+
+    def __init__(self, hass: HomeAssistant, config: dict[str, str | int]):
+        self.hass = hass
+        self.config = config
+
+    async def get(self, request: web.Request, entry_id: str):
+        if entry_id != self.config["entry_id"]:
+            return web.Response(status=404)
+        ws = web.WebSocketResponse()
+        await ws.prepare(request)
+        reader, writer = await asyncio.open_connection(
+            self.config[CONF_HOST], self.config[CONF_PORT]
+        )
+
+        async def ws_to_tcp() -> None:
+            async for msg in ws:
+                if msg.type == WSMsgType.BINARY:
+                    writer.write(msg.data)
+                    await writer.drain()
+
+        async def tcp_to_ws() -> None:
+            try:
+                while True:
+                    data = await reader.read(1024)
+                    if not data:
+                        break
+                    await ws.send_bytes(data)
+            finally:
+                await ws.close()
+
+        await asyncio.gather(ws_to_tcp(), tcp_to_ws())
+        writer.close()
+        await writer.wait_closed()
+        return ws
+
+
+async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
+    """Set up VNC from a config entry."""
+    config = {
+        "entry_id": entry.entry_id,
+        CONF_HOST: entry.data[CONF_HOST],
+        CONF_PORT: entry.data[CONF_PORT],
+    }
+    view = VncProxyView(hass, config)
+    hass.http.register_view(view)
+    static_path = hass.config.path("custom_components/vnc/static")
+    hass.http.register_static_path(
+        f"/vnc_static/{entry.entry_id}", static_path, cache_headers=False
+    )
+    hass.data.setdefault(DOMAIN, {})[entry.entry_id] = view
+
+    hass.components.frontend.async_register_built_in_panel(
+        "iframe",
+        {"url": f"/vnc_static/{entry.entry_id}/index.html?entry={entry.entry_id}"},
+        sidebar_title=entry.title or entry.data[CONF_HOST],
+        sidebar_icon="mdi:monitor",
+        panel_id=entry.entry_id,
+    )
+    return True
+
+
+async def async_unload_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
+    """Unload a config entry."""
+    hass.components.frontend.async_remove_panel(entry.entry_id)
+    hass.data[DOMAIN].pop(entry.entry_id, None)
+    hass.http.unregister_path(f"/vnc_static/{entry.entry_id}")
+    return True

--- a/custom_components/vnc/config_flow.py
+++ b/custom_components/vnc/config_flow.py
@@ -1,0 +1,28 @@
+from __future__ import annotations
+
+import voluptuous as vol
+from homeassistant import config_entries
+from homeassistant.const import CONF_HOST, CONF_PORT
+
+from .const import DOMAIN, DEFAULT_PORT
+
+
+class VncConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
+    """Handle a config flow for VNC."""
+
+    VERSION = 1
+
+    async def async_step_user(self, user_input: dict | None = None):
+        """Handle the initial step."""
+        errors: dict[str, str] = {}
+
+        if user_input is not None:
+            return self.async_create_entry(title=user_input[CONF_HOST], data=user_input)
+
+        data_schema = vol.Schema(
+            {
+                vol.Required(CONF_HOST): str,
+                vol.Optional(CONF_PORT, default=DEFAULT_PORT): int,
+            }
+        )
+        return self.async_show_form(step_id="user", data_schema=data_schema, errors=errors)

--- a/custom_components/vnc/const.py
+++ b/custom_components/vnc/const.py
@@ -1,0 +1,2 @@
+DOMAIN = "vnc"
+DEFAULT_PORT = 5900

--- a/custom_components/vnc/manifest.json
+++ b/custom_components/vnc/manifest.json
@@ -1,0 +1,11 @@
+{
+  "domain": "vnc",
+  "name": "VNC Viewer",
+  "version": "0.1.0",
+  "documentation": "https://example.com",
+  "requirements": [],
+  "dependencies": [],
+  "codeowners": ["@yourhandle"],
+  "config_flow": true,
+  "iot_class": "local_push"
+}

--- a/custom_components/vnc/manifest.json
+++ b/custom_components/vnc/manifest.json
@@ -2,10 +2,11 @@
   "domain": "vnc",
   "name": "VNC Viewer",
   "version": "0.1.0",
-  "documentation": "https://example.com",
+  "documentation": "https://Brüser.com",
+  "issue_tracker": "https://github.com/404GamerNotFound/ha-vnc/issues",
   "requirements": [],
   "dependencies": [],
-  "codeowners": ["@yourhandle"],
+  "codeowners": ["@404GamerNotFound"],
   "config_flow": true,
   "iot_class": "local_push"
 }

--- a/custom_components/vnc/static/index.html
+++ b/custom_components/vnc/static/index.html
@@ -1,0 +1,24 @@
+<!doctype html>
+<html>
+  <head>
+    <meta charset="utf-8" />
+    <title>VNC Viewer</title>
+    <script src="https://cdn.jsdelivr.net/npm/novnc@1.4.0/core/rfb.js"></script>
+    <style>
+      html, body, #screen {
+        height: 100%;
+        margin: 0;
+      }
+    </style>
+  </head>
+  <body>
+    <div id="screen"></div>
+    <script>
+      const params = new URLSearchParams(location.search);
+      const entry = params.get('entry');
+      const url = `${location.protocol.replace('http', 'ws')}//${location.host}/api/vnc/${entry}`;
+      const rfb = new RFB(document.getElementById('screen'), url);
+      rfb.viewOnly = false;
+    </script>
+  </body>
+</html>

--- a/custom_components/vnc/translations/en.json
+++ b/custom_components/vnc/translations/en.json
@@ -1,0 +1,14 @@
+{
+  "title": "VNC",
+  "config": {
+    "step": {
+      "user": {
+        "title": "Connect to VNC",
+        "data": {
+          "host": "Host",
+          "port": "Port"
+        }
+      }
+    }
+  }
+}

--- a/hacs.json
+++ b/hacs.json
@@ -1,0 +1,6 @@
+{
+  "name": "VNC Viewer",
+  "domain": "vnc",
+  "render_readme": true,
+  "homeassistant": "2023.8.0"
+}

--- a/tests/test_const.py
+++ b/tests/test_const.py
@@ -1,0 +1,13 @@
+import importlib.util
+from pathlib import Path
+
+spec = importlib.util.spec_from_file_location(
+    "vnc_const", Path(__file__).parent.parent / "custom_components" / "vnc" / "const.py"
+)
+const = importlib.util.module_from_spec(spec)
+spec.loader.exec_module(const)
+
+
+def test_constants():
+    assert const.DOMAIN == "vnc"
+    assert const.DEFAULT_PORT == 5900


### PR DESCRIPTION
## Summary
- add custom VNC integration for HACS with config flow
- proxy VNC via Home Assistant websocket and show noVNC panel

## Testing
- `python -m py_compile custom_components/vnc/*.py`


------
https://chatgpt.com/codex/tasks/task_e_68ba670a2b1c8327868f62dea54a1775