### PR TITLE
Fix documentation links for HACS

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,4 +10,4 @@ that opens the remote desktop within Home Assistant.
 This repository works with [HACS](https://hacs.xyz/). Add it as a custom repository and install the VNC integration.
 
 - Code owner: [404GamerNotFound](https://github.com/404GamerNotFound)
-- Documentation: https://Brüser.com
+- Documentation: https://github.com/404GamerNotFound/ha-vnc

--- a/custom_components/vnc/manifest.json
+++ b/custom_components/vnc/manifest.json
@@ -2,7 +2,7 @@
   "domain": "vnc",
   "name": "VNC Viewer",
   "version": "0.1.0",
-  "documentation": "https://Brüser.com",
+  "documentation": "https://github.com/404GamerNotFound/ha-vnc",
   "issue_tracker": "https://github.com/404GamerNotFound/ha-vnc/issues",
   "requirements": [],
   "dependencies": [],


### PR DESCRIPTION
## Summary
- Replace placeholder documentation URL with project repository link in manifest
- Align README documentation link with manifest for HACS compliance

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68ba6eea0a2083279db6cd305dd4583b